### PR TITLE
Add 'curses' dependency

### DIFF
--- a/btct.gemspec
+++ b/btct.gemspec
@@ -15,4 +15,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.executables << 'btct'
+
+  s.add_runtime_dependency 'curses', '~> 1.0'
 end


### PR DESCRIPTION
The `curses` library is no longer part of the Ruby standard library in Ruby 2.1.0 and newer.